### PR TITLE
Change references from twitter.com -> x.com

### DIFF
--- a/BlueLiteBlocker/chrome_manifest.json
+++ b/BlueLiteBlocker/chrome_manifest.json
@@ -35,7 +35,7 @@
 
   "web_accessible_resources": [{
       "resources": ["xhr_hook.js"],
-      "matches": [ "*://*.twitter.com/*" ]
+      "matches": [ "*://*.x.com/*" ]
     }],
 
   "background": {
@@ -44,7 +44,7 @@
 
   "content_scripts": [
     {
-      "matches": ["*://*.twitter.com/*"],
+      "matches": ["*://*.x.com/*"],
       "run_at": "document_start",
       "js": ["injector.js"]
     }

--- a/BlueLiteBlocker/firefox_manifest.json
+++ b/BlueLiteBlocker/firefox_manifest.json
@@ -41,7 +41,7 @@
 
   "content_scripts": [
     {
-      "matches": ["*://*.twitter.com/*"],
+      "matches": ["*://*.x.com/*"],
       "run_at": "document_start",
       "js": ["injector.js"]
     }

--- a/BlueLiteBlocker/xhr_hook.js
+++ b/BlueLiteBlocker/xhr_hook.js
@@ -40,8 +40,8 @@
         if (arguments.length >= 2 && arguments[0] !== "") {
 
             // hook HomeTimeline API to parse timeline tweets
-            if (arguments[1].search('https://twitter.com/i/api/graphql/.*/HomeTimeline') !== -1 ||
-                arguments[1].search('https://twitter.com/i/api/graphql/.*/HomeLatestTimeline') !== -1
+            if (arguments[1].search('https://x.com/i/api/graphql/.*/HomeTimeline') !== -1 ||
+                arguments[1].search('https://x.com/i/api/graphql/.*/HomeLatestTimeline') !== -1
             ) {
                 if (!this._xhr_response_hooked) {
                     this._xhr_response_hooked = true;
@@ -50,7 +50,7 @@
             }
 
             // hook TweetDetail API to parse tweet replies
-            if (arguments[1].search('https://twitter.com/i/api/graphql/.*/TweetDetail') !== -1) {
+            if (arguments[1].search('https://x.com/i/api/graphql/.*/TweetDetail') !== -1) {
                 if (!this._xhr_response_hooked) {
                     this._xhr_response_hooked = true;
                     set_response_hook(this, 'replies');
@@ -58,7 +58,7 @@
             }
 
             // hook search API to parse search and trending topics
-            if (arguments[1].search('https://twitter.com/i/api/2/search/adaptive.json') !== -1) {
+            if (arguments[1].search('https://x.com/i/api/2/search/adaptive.json') !== -1) {
                 if (!this._xhr_response_hooked) {
                     this._xhr_response_hooked = true;
                     set_response_hook(this, 'search');
@@ -66,8 +66,8 @@
             }
 
             // hook notifications API to parse notification feed
-            if (arguments[1].search('https://twitter.com/i/api/2/notifications/all.json') !== -1 ||
-                arguments[1].search('https://twitter.com/i/api/2/notifications/mentions.json') !== -1) {
+            if (arguments[1].search('https://x.com/i/api/2/notifications/all.json') !== -1 ||
+                arguments[1].search('https://x.com/i/api/2/notifications/mentions.json') !== -1) {
                 if (!this._xhr_response_hooked) {
                     this._xhr_response_hooked = true;
                     set_response_hook(this, 'search');

--- a/Instructions/Chrome/chrome_install.md
+++ b/Instructions/Chrome/chrome_install.md
@@ -29,12 +29,12 @@ Click the "Details" button on the BlueLiteBlock extension widget
 
 ![](extension_details.png)
 
-Ensure the `*://*.twitter.com/*` permission is enabled (blue)
+Ensure the `*://*.x.com/*` permission is enabled (blue)
 
 ![](enable_permissions.png)
 
 ### Configure the settings
-If you wish to change any settings, simply navigate to twitter.com and click the puzzle icon in to top right corner, followed by the extension icon.
+If you wish to change any settings, simply navigate to x.com and click the puzzle icon in to top right corner, followed by the extension icon.
 
 This will open the configuration page.
 

--- a/Instructions/Firefox/firefox_install.md
+++ b/Instructions/Firefox/firefox_install.md
@@ -25,12 +25,12 @@ click on the BlueLiteBlocker extension
 
 ![](manage_extensions.png)
 
-Ensure the `*://twitter.com/` permission is enabled (blue)
+Ensure the `*://x.com/` permission is enabled (blue)
 
 ![](enable_permissions.png)
 
 ### Configure the settings
-If you wish to change any settings, simply navigate to twitter.com and click the puzzle icon in to top right corner, followed by the extension icon.
+If you wish to change any settings, simply navigate to x.com and click the puzzle icon in to top right corner, followed by the extension icon.
 
 This will open the configuration page.
 

--- a/readme.md
+++ b/readme.md
@@ -64,5 +64,5 @@ testing.
 
 
 ## Updates
-Follow me on https://twitter.com/BlueLiteBlocker for updates.
+Follow me on https://x.com/BlueLiteBlocker for updates.
  


### PR DESCRIPTION
`twitter.com` now permanently redirects to `x.com`, so this changes all references to get this extension to work again. Pour one out for the old domain.